### PR TITLE
fix remove not needed className check

### DIFF
--- a/blocks/demo/edit.js
+++ b/blocks/demo/edit.js
@@ -25,12 +25,6 @@ const Edit = ( { isSelected, attributes, setAttributes } ) => {
 		description,
 	} = attributes;
 
-	let { className } = attributes;
-
-	if ( undefined === className ) {
-		className = '';
-	}
-
 	return (
 		<>
 			<div {...blockProps}>


### PR DESCRIPTION
The `useBlockProps` takes care of adding the custom class to the
wrapping container for you